### PR TITLE
Add audio silence splitting and metrics

### DIFF
--- a/analize/README.md
+++ b/analize/README.md
@@ -16,6 +16,12 @@ Analyze a file:
 analize full input.wav -o report.txt
 ```
 
+Split on long silences (e.g., segments separated by ≥1s of silence and trim 0.2s from edges):
+
+```
+analize full speech.wav -split-on-silence 1 -trim-ends 0.2
+```
+
 Compare two files:
 
 ```

--- a/analize/analysis.go
+++ b/analize/analysis.go
@@ -58,13 +58,17 @@ func analyzeFile(cfg *Config, in string) (*Analysis, error) {
 
 	sil, _ := detectSilences(cfg, in)
 	var silRatio *float64
-	if len(sil) > 0 && probe.Duration > 0 {
+	var silTotal *float64
+	if len(sil) > 0 {
 		var dur float64
 		for _, sp := range sil {
 			dur += sp.End - sp.Start
 		}
-		v := (dur / probe.Duration)
-		silRatio = &v
+		silTotal = &dur
+		if probe.Duration > 0 {
+			v := dur / probe.Duration
+			silRatio = &v
+		}
 	}
 
 	var tempo *TempoStats
@@ -104,6 +108,6 @@ func analyzeFile(cfg *Config, in string) (*Analysis, error) {
 		File: in, When: time.Now().Format(time.RFC3339),
 		Probe: probe, Level: lv, Loudness: lufs, Stereo: st, Spectral: spec,
 		Bands: bands, Tempo: tempo, Pitch: ps, Key: key,
-		Silence: sil, SilenceRatio: silRatio, Notes: notes,
+		Silence: sil, SilenceRatio: silRatio, SilenceTotal: silTotal, Notes: notes,
 	}, nil
 }

--- a/analize/main.go
+++ b/analize/main.go
@@ -20,6 +20,8 @@ func main() {
 	noEbu := flag.Bool("no-ebur128", false, "disable LUFS ebur128/true peak")
 	astWin := flag.Float64("astats-window", 0.0, "astats window sec (0=overall)")
 	silTh := flag.Float64("silence-threshold", cfg.SilThresDB, "silence threshold dBFS")
+	splitSec := flag.Float64("split-on-silence", 0.0, "split input on silence >= seconds (0=off)")
+	trimSec := flag.Float64("trim-ends", 0.0, "trim this many seconds from start/end of segments")
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "analit — overkill audio analysis\n\n")
 		fmt.Fprintf(os.Stderr, "Usage:\n  analit full <input> [flags]\n  analit compare <inputA> <inputB> [flags]\n\n")
@@ -71,6 +73,11 @@ func main() {
 			fail("write: %v", err)
 		}
 		fmt.Printf("[+] wrote %s\n", cfg.OutPath)
+		if *splitSec > 0 {
+			if _, err := splitBySilence(cfg, in, a, *splitSec, *trimSec); err != nil {
+				fail("split: %v", err)
+			}
+		}
 
 	case "compare":
 		if len(args) < 3 {

--- a/analize/render.go
+++ b/analize/render.go
@@ -133,6 +133,9 @@ func renderTXT(a *Analysis) string {
 		for _, s := range a.Silence {
 			fmt.Fprintf(&b, "  %.3f → %.3f (%.3fs)\n", s.Start, s.End, s.End-s.Start)
 		}
+		if a.SilenceTotal != nil {
+			fmt.Fprintf(&b, "Total silence: %.3fs\n", *a.SilenceTotal)
+		}
 		if a.SilenceRatio != nil {
 			fmt.Fprintf(&b, "Silence ratio: %.2f%% of duration\n", *a.SilenceRatio*100)
 		}
@@ -266,6 +269,9 @@ func renderMD(a *Analysis) string {
 		fmt.Fprintf(&b, "## Silence\n")
 		for _, s := range a.Silence {
 			fmt.Fprintf(&b, "- `%.3f → %.3f` (%.3fs)\n", s.Start, s.End, s.End-s.Start)
+		}
+		if a.SilenceTotal != nil {
+			fmt.Fprintf(&b, "- Total silence: `%.3fs`\n", *a.SilenceTotal)
 		}
 		if a.SilenceRatio != nil {
 			fmt.Fprintf(&b, "- Silence ratio: `%.2f%%`\n", *a.SilenceRatio*100)

--- a/analize/silence_split.go
+++ b/analize/silence_split.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"path/filepath"
+	"strings"
+)
+
+type segment struct{ start, end float64 }
+
+// splitBySilence splits input file into segments based on silence spans longer
+// than minSilDur seconds. It trims `trim` seconds from the start and end of
+// each segment. Returned slice contains paths of created files.
+func splitBySilence(cfg *Config, in string, a *Analysis, minSilDur, trim float64) ([]string, error) {
+	spans := a.Silence
+	dur := a.Probe.Duration
+	// build segments between silence spans
+	var segs []segment
+	start := 0.0
+	for _, s := range spans {
+		if (s.End - s.Start) >= minSilDur {
+			segs = append(segs, segment{start, s.Start})
+			start = s.End
+		}
+	}
+	if start < dur {
+		segs = append(segs, segment{start, dur})
+	}
+	if len(segs) <= 1 { // nothing to split
+		return nil, nil
+	}
+	base := strings.TrimSuffix(in, filepath.Ext(in))
+	ext := filepath.Ext(in)
+	var outs []string
+	for i, sg := range segs {
+		s := sg.start
+		e := sg.end
+		if trim > 0 {
+			s = math.Min(e, s+trim)
+			e = math.Max(s, e-trim)
+		}
+		out := fmt.Sprintf("%s-part%02d%s", base, i+1, ext)
+		args := []string{"-y", "-i", in, "-ss", fmt.Sprintf("%f", s), "-to", fmt.Sprintf("%f", e), "-c", "copy", out}
+		if _, err := runCmd(cfg.FFmpegBin, args...); err != nil {
+			return outs, fmt.Errorf("ffmpeg split: %w", err)
+		}
+		fmt.Printf("[+] wrote %s\n", out)
+		outs = append(outs, out)
+	}
+	return outs, nil
+}

--- a/analize/types.go
+++ b/analize/types.go
@@ -92,6 +92,7 @@ type Analysis struct {
 	Key          *KeyInfo
 	Silence      []SilenceSpan
 	SilenceRatio *float64
+	SilenceTotal *float64
 	Notes        []string // warnings/suggestions
 }
 


### PR DESCRIPTION
## Summary
- add `split-on-silence` and `trim-ends` flags to `analize` for detecting long quiet sections and producing per-segment files
- compute and report total silence duration during analysis output
- document new options and implement helper for splitting tracks at silence

## Testing
- `go build -o /tmp/analize ./analize`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c124b9c060832da9bb2163eb2845b0